### PR TITLE
Support rolling negative times

### DIFF
--- a/pas.rb
+++ b/pas.rb
@@ -88,6 +88,9 @@ end
 def sroll
   roll = @stack.pop
   depth = @stack.pop
+  if roll < 0 then
+    roll = roll % depth + depth
+  end
   roll.times do
     sroll1 depth
   end


### PR DESCRIPTION
負数のrollに対応します。
-x回のrollはsroll1と逆の操作をx回繰り返しますが、これは-x mod depth回sroll1を繰り返すのと同じことです。